### PR TITLE
投稿用API設計とAPIGateway設定の調査 #3

### DIFF
--- a/Terraform/modules/lambda/apigateway.tf
+++ b/Terraform/modules/lambda/apigateway.tf
@@ -1,32 +1,22 @@
 resource "aws_api_gateway_rest_api" "this" {
   name = "${var.identifier}-apigateway"
+  body = data.template_file.openapi.rendered
+
   endpoint_configuration {
     types = ["REGIONAL"]
   }
 }
 
-resource "aws_api_gateway_resource" "this" {
-  rest_api_id = aws_api_gateway_rest_api.this.id
-  parent_id   = aws_api_gateway_rest_api.this.root_resource_id
-  path_part   = "hello"
-}
+data "template_file" "openapi" {
+  template = file("${path.module}/openapi.yaml")
 
-resource "aws_api_gateway_method" "this" {
-  rest_api_id   = aws_api_gateway_rest_api.this.id
-  resource_id   = aws_api_gateway_resource.this.id
-  http_method   = "GET"
-  authorization = "COGNITO_USER_POOLS"
-  authorizer_id = aws_api_gateway_authorizer.this.id
-}
-
-resource "aws_api_gateway_integration" "this" {
-  rest_api_id             = aws_api_gateway_rest_api.this.id
-  resource_id             = aws_api_gateway_resource.this.id
-  http_method             = aws_api_gateway_method.this.http_method
-  integration_http_method = "POST"
-  type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.this.invoke_arn
-  credentials             = aws_iam_role.api2lambda.arn
+  vars = {
+    name                = "${var.identifier}-apigateway"
+    auth                = "${var.identifier}-apigateway-auth"
+    auth_provider_arn   = aws_cognito_user_pool.this.arn
+    integration_uri     = aws_lambda_function.this.invoke_arn
+    credential_role_arn = aws_iam_role.api2lambda.arn
+  }
 }
 
 # IAM Role for API Gateway Execution Lambda
@@ -70,75 +60,21 @@ resource "aws_iam_policy" "api2lambda" {
 EOF
 }
 
-
-# CORS
-resource "aws_api_gateway_method" "option" {
-  rest_api_id   = aws_api_gateway_rest_api.this.id
-  resource_id   = aws_api_gateway_resource.this.id
-  http_method   = "OPTIONS"
-  authorization = "NONE"
-}
-
-resource "aws_api_gateway_method_response" "option" {
-  rest_api_id = aws_api_gateway_rest_api.this.id
-  resource_id = aws_api_gateway_resource.this.id
-  http_method = aws_api_gateway_method.option.http_method
-  status_code = "200"
-  response_models = {
-    "application/json" = "Empty"
-  }
-  response_parameters = {
-    "method.response.header.Access-Control-Allow-Headers" = true
-    "method.response.header.Access-Control-Allow-Methods" = true
-    "method.response.header.Access-Control-Allow-Origin"  = true
-  }
-}
-
-resource "aws_api_gateway_integration" "option" {
-  rest_api_id          = aws_api_gateway_rest_api.this.id
-  resource_id          = aws_api_gateway_resource.this.id
-  http_method          = aws_api_gateway_method.option.http_method
-  type                 = "MOCK"
-  passthrough_behavior = "WHEN_NO_MATCH"
-  request_templates = {
-    "application/json" = jsonencode(
-      {
-        statusCode = 200
-      }
-    )
-  }
-}
-
-resource "aws_api_gateway_integration_response" "option" {
-  rest_api_id = aws_api_gateway_rest_api.this.id
-  resource_id = aws_api_gateway_resource.this.id
-  http_method = aws_api_gateway_method.option.http_method
-  status_code = aws_api_gateway_method_response.option.status_code
-  response_parameters = {
-    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-    "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'"
-    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
-  }
-}
-
 # deploy
 resource "aws_api_gateway_deployment" "this" {
+  depends_on = [
+    aws_api_gateway_rest_api.this
+  ]
+
   rest_api_id = aws_api_gateway_rest_api.this.id
 
   triggers = {
-    redeployment = join("", [
-      for file in fileset(path.module, "./**/*.tf")
-      : filebase64("${path.module}/${file}")
-    ])
+    redeployment = sha1(file("${path.module}/openapi.yaml"))
   }
 
   lifecycle {
     create_before_destroy = true
   }
-
-  depends_on = [
-    aws_api_gateway_integration.this
-  ]
 }
 
 resource "aws_api_gateway_stage" "this" {
@@ -183,7 +119,7 @@ resource "aws_lambda_permission" "this" {
   principal     = "apigateway.amazonaws.com"
 
   # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
-  source_arn = "arn:aws:execute-api:${var.region}:${var.accountId}:${aws_api_gateway_rest_api.this.id}/${var.env}/${aws_api_gateway_method.this.http_method}${aws_api_gateway_resource.this.path}"
+  source_arn = "arn:aws:execute-api:${var.region}:${var.accountId}:${aws_api_gateway_rest_api.this.id}/${var.env}/*"
 }
 
 # IAM Role for API Gateway Put CloudWatch Logs
@@ -207,14 +143,5 @@ resource "aws_iam_role" "apigateway_putlog" {
 EOF
   managed_policy_arns = [
     "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
-  ]
-}
-
-resource "aws_api_gateway_authorizer" "this" {
-  rest_api_id = aws_api_gateway_rest_api.this.id
-  name        = "${var.identifier}-apigateway-auth"
-  type        = "COGNITO_USER_POOLS"
-  provider_arns = [
-    aws_cognito_user_pool.this.arn
   ]
 }

--- a/Terraform/modules/lambda/apigateway.tf
+++ b/Terraform/modules/lambda/apigateway.tf
@@ -69,7 +69,7 @@ resource "aws_api_gateway_deployment" "this" {
   rest_api_id = aws_api_gateway_rest_api.this.id
 
   triggers = {
-    redeployment = sha1(file("${path.module}/openapi.yaml"))
+    redeployment = sha256(file("${path.module}/openapi.yaml"))
   }
 
   lifecycle {

--- a/Terraform/modules/lambda/lambda.tf
+++ b/Terraform/modules/lambda/lambda.tf
@@ -36,10 +36,10 @@ resource "null_resource" "this" {
   depends_on = [aws_s3_bucket.this]
 
   triggers = {
-    code_diff = join("", [
+    code_diff = sha256(join("", [
       for file in fileset(local.golang_codedir_local_path, "./**/*.go")
       : filebase64("${local.golang_codedir_local_path}/${file}")
-    ])
+    ]))
   }
 
   provisioner "local-exec" {

--- a/Terraform/modules/lambda/openapi.yaml
+++ b/Terraform/modules/lambda/openapi.yaml
@@ -2,25 +2,25 @@ openapi: 3.0.1
 x-stoplight:
   id: ty0l0m8lth33t
 info:
-  title: '${name}'
-  version: '2023-03-06T07:01:08Z'
+  title: "${name}"
+  version: "2023-03-06T07:01:08Z"
   contact:
     name: chocono2230
-  description: 61bcプロジェクト用APIドキュメント
+  description: 61bcプロジェクト用API
 paths:
   /hello:
     get:
       security:
-        - '${auth}': []
+        - "${auth}": []
       x-amazon-apigateway-integration:
         type: aws_proxy
-        uri: '${lpermission_source_arn}'
-        credentials: '${credential_role}'
+        uri: "${integration_uri}"
+        credentials: "${credential_role_arn}"
         httpMethod: POST
         passthroughBehavior: when_no_match
         timeoutInMillis: 29000
       responses:
-        '200':
+        "200":
           description: OK
       x-internal: true
       tags:
@@ -29,7 +29,7 @@ paths:
       operationId: hello
     options:
       responses:
-        '200':
+        "200":
           description: 200 response
           headers:
             Access-Control-Allow-Origin:
@@ -44,16 +44,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Empty'
+                $ref: "#/components/schemas/Empty"
       x-amazon-apigateway-integration:
         type: mock
         responses:
           default:
-            statusCode: '200'
+            statusCode: "200"
             responseParameters:
-              method.response.header.Access-Control-Allow-Methods: '''GET,OPTIONS'''
-              method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'''
-              method.response.header.Access-Control-Allow-Origin: '''*'''
+              method.response.header.Access-Control-Allow-Methods: "'GET,OPTIONS'"
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
         requestTemplates:
           application/json: '{"statusCode":200}'
         passthroughBehavior: when_no_match
@@ -68,7 +68,7 @@ components:
       title: Empty Schema
       type: object
   securitySchemes:
-    '${auth}':
+    "${auth}":
       type: apiKey
       name: Authorization
       in: header
@@ -76,7 +76,7 @@ components:
       x-amazon-apigateway-authorizer:
         type: cognito_user_pools
         providerARNs:
-          - '${auth_provider_arn}'
+          - "${auth_provider_arn}"
 x-internal: true
 tags:
   - name: Test

--- a/Terraform/modules/lambda/openapi.yaml
+++ b/Terraform/modules/lambda/openapi.yaml
@@ -1,0 +1,82 @@
+openapi: 3.0.1
+x-stoplight:
+  id: ty0l0m8lth33t
+info:
+  title: '${name}'
+  version: '2023-03-06T07:01:08Z'
+  contact:
+    name: chocono2230
+  description: 61bcプロジェクト用APIドキュメント
+paths:
+  /hello:
+    get:
+      security:
+        - '${auth}': []
+      x-amazon-apigateway-integration:
+        type: aws_proxy
+        uri: '${lpermission_source_arn}'
+        credentials: '${credential_role}'
+        httpMethod: POST
+        passthroughBehavior: when_no_match
+        timeoutInMillis: 29000
+      responses:
+        '200':
+          description: OK
+      x-internal: true
+      tags:
+        - Test
+      description: 試験エンドポイント
+      operationId: hello
+    options:
+      responses:
+        '200':
+          description: 200 response
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Empty'
+      x-amazon-apigateway-integration:
+        type: mock
+        responses:
+          default:
+            statusCode: '200'
+            responseParameters:
+              method.response.header.Access-Control-Allow-Methods: '''GET,OPTIONS'''
+              method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'''
+              method.response.header.Access-Control-Allow-Origin: '''*'''
+        requestTemplates:
+          application/json: '{"statusCode":200}'
+        passthroughBehavior: when_no_match
+        timeoutInMillis: 29000
+      description: CORS/プリフライトリクエスト
+      operationId: cors
+      tags:
+        - Test
+components:
+  schemas:
+    Empty:
+      title: Empty Schema
+      type: object
+  securitySchemes:
+    '${auth}':
+      type: apiKey
+      name: Authorization
+      in: header
+      x-amazon-apigateway-authtype: cognito_user_pools
+      x-amazon-apigateway-authorizer:
+        type: cognito_user_pools
+        providerARNs:
+          - '${auth_provider_arn}'
+x-internal: true
+tags:
+  - name: Test


### PR DESCRIPTION
close #3 
API設計はNotionドキュメント参照
APIGatewayの設定方法をOpenAPIによる指定に変更
変更検知をbase64エンコーディング後に連結し、それをsha256した結果を参照する