### PR TITLE
Post全件取得APIの作成 #16

### DIFF
--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -28,22 +28,28 @@ provider "aws" {
 }
 
 locals {
-  identifier = "${var.env}-${var.project}"
+  identifier   = "${var.env}-${var.project}"
+  gsi_name_all = "${local.identifier}-ddb-posts-gsi-alltime"
+  gsi_name_usr = "${local.identifier}-ddb-posts-gsi-usrtime"
 }
 
 module "lambda" {
   depends_on = [
     module.dynamoDB
   ]
-  source           = "./modules/lambda"
-  identifier       = local.identifier
-  env              = var.env
-  region           = var.region
-  accountId        = var.accountId
-  posts_table_name = module.dynamoDB.posts_table_name
+  source                   = "./modules/lambda"
+  identifier               = local.identifier
+  env                      = var.env
+  region                   = var.region
+  accountId                = var.accountId
+  posts_table_name         = module.dynamoDB.posts_table_name
+  posts_table_gsi_name_all = local.gsi_name_all
+  posts_table_gsi_name_usr = local.gsi_name_usr
 }
 
 module "dynamoDB" {
-  source     = "./modules/dynamoDB"
-  identifier = local.identifier
+  source       = "./modules/dynamoDB"
+  identifier   = local.identifier
+  gsi_name_all = local.gsi_name_all
+  gsi_name_usr = local.gsi_name_usr
 }

--- a/Terraform/modules/dynamoDB/dynamoDB.tf
+++ b/Terraform/modules/dynamoDB/dynamoDB.tf
@@ -24,14 +24,14 @@ resource "aws_dynamodb_table" "posts_table" {
   }
 
   global_secondary_index {
-    name            = "${var.identifier}-ddb-posts-gsi-alltime"
+    name            = var.gsi_name_all
     hash_key        = "gsiSKey"
     range_key       = "timestamp"
     projection_type = "ALL"
   }
 
   global_secondary_index {
-    name            = "${var.identifier}-ddb-posts-gsi-usrtime"
+    name            = var.gsi_name_usr
     hash_key        = "userId"
     range_key       = "timestamp"
     projection_type = "ALL"

--- a/Terraform/modules/dynamoDB/variables.tf
+++ b/Terraform/modules/dynamoDB/variables.tf
@@ -1,3 +1,9 @@
 variable "identifier" {
   type = string
 }
+variable "gsi_name_all" {
+  type = string
+}
+variable "gsi_name_usr" {
+  type = string
+}

--- a/Terraform/modules/lambda/lambda.tf
+++ b/Terraform/modules/lambda/lambda.tf
@@ -44,27 +44,30 @@ resource "aws_iam_role" "lambda" {
 resource "aws_iam_policy" "lambda2dynamodb" {
   name = "${var.identifier}-lambda-dynamodb-policy"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-        "Sid": "ReadWriteTable",
-        "Effect": "Allow",
-        "Action": [
-            "dynamodb:BatchGetItem",
-            "dynamodb:GetItem",
-            "dynamodb:Query",
-            "dynamodb:Scan",
-            "dynamodb:BatchWriteItem",
-            "dynamodb:PutItem",
-            "dynamodb:UpdateItem"
-        ],
-        "Resource": "arn:aws:dynamodb:*:*:table/${var.posts_table_name}"
-    }
-  ]
-}
-EOF
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+          "Sid": "ReadWriteTable",
+          "Effect": "Allow",
+          "Action": [
+              "dynamodb:BatchGetItem",
+              "dynamodb:GetItem",
+              "dynamodb:Query",
+              "dynamodb:Scan",
+              "dynamodb:BatchWriteItem",
+              "dynamodb:PutItem",
+              "dynamodb:UpdateItem"
+          ],
+          "Resource": [
+            "arn:aws:dynamodb:*:*:table/${var.posts_table_name}",
+            "arn:aws:dynamodb:*:*:table/${var.posts_table_name}/index/${var.posts_table_gsi_name_all}"
+          ]
+      }
+    ]
+  }
+  EOF
 }
 
 resource "null_resource" "this" {

--- a/Terraform/modules/lambda/lambda.tf
+++ b/Terraform/modules/lambda/lambda.tf
@@ -10,7 +10,9 @@ resource "aws_lambda_function" "this" {
 
   environment {
     variables = {
-      POSTS_TABLE_NAME = var.posts_table_name
+      POSTS_TABLE_NAME         = var.posts_table_name
+      POSTS_TABLE_GSI_NAME_ALL = var.posts_table_gsi_name_all
+      POSTS_TABLE_GSI_NAME_USR = var.posts_table_gsi_name_usr
     }
   }
 }

--- a/Terraform/modules/lambda/src/posts/root-get.go
+++ b/Terraform/modules/lambda/src/posts/root-get.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
 )
 
 func get(request events.APIGatewayProxyRequest) (any, int, error) {
@@ -48,5 +49,15 @@ func getAllPost() (any, int, error) {
 		return err.Error(), 500, nil
 	}
 
-	return result, 200, nil
+	posts := []Post{}
+	err = dynamodbattribute.UnmarshalListOfMaps(result.Items, &posts)
+	if err != nil {
+		return err.Error(), 500, nil
+	}
+	response := struct {
+		Posts []Post `json:"posts"`
+	}{
+		Posts: posts,
+	}
+	return response, 200, nil
 }

--- a/Terraform/modules/lambda/src/posts/root-get.go
+++ b/Terraform/modules/lambda/src/posts/root-get.go
@@ -1,0 +1,52 @@
+package posts
+
+import (
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+func get(request events.APIGatewayProxyRequest) (any, int, error) {
+	uid := request.QueryStringParameters["userid"]
+
+	switch {
+	case uid != "":
+		return "that feature has not been implemented", 400, nil
+	default:
+		return getAllPost()
+	}
+}
+
+func getAllPost() (any, int, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return err.Error(), 500, nil
+	}
+	db := dynamodb.New(sess)
+
+	tn := os.Getenv("POSTS_TABLE_NAME")
+	in := os.Getenv("POSTS_TABLE_GSI_NAME_ALL")
+	input := &dynamodb.QueryInput{
+		IndexName: aws.String(in),
+		TableName: aws.String(tn),
+		ExpressionAttributeNames: map[string]*string{
+			"#gsiSKey": aws.String("gsiSKey"),
+		},
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":gsiSKey": {
+				S: aws.String("SKEY"),
+			},
+		},
+		KeyConditionExpression: aws.String("#gsiSKey = :gsiSKey"),
+		ScanIndexForward:       aws.Bool(false),
+	}
+	result, err := db.Query(input)
+	if err != nil {
+		return err.Error(), 500, nil
+	}
+
+	return result, 200, nil
+}

--- a/Terraform/modules/lambda/src/posts/root.go
+++ b/Terraform/modules/lambda/src/posts/root.go
@@ -19,6 +19,8 @@ func Root(request events.APIGatewayProxyRequest) (any, int, error) {
 	if len(pathArray) == 0 {
 		method := request.HTTPMethod
 		switch method {
+		case "GET":
+			return get(request)
 		case "POST":
 			return post(request)
 		}

--- a/Terraform/modules/lambda/variables.tf
+++ b/Terraform/modules/lambda/variables.tf
@@ -14,3 +14,9 @@ variable "accountId" {
 variable "posts_table_name" {
   type = string
 }
+variable "posts_table_gsi_name_all" {
+  type = string
+}
+variable "posts_table_gsi_name_usr" {
+  type = string
+}


### PR DESCRIPTION
close #16 
dynamoDBのGSIを用いて、timestampを基にソートした結果を返却している
GSIのname共有のために、tfでの名前指定箇所を変更している