### PR TITLE
Errorの扱いについて修正 #21

### DIFF
--- a/Terraform/modules/lambda/src/posts/root-get.go
+++ b/Terraform/modules/lambda/src/posts/root-get.go
@@ -1,6 +1,7 @@
 package posts
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -15,7 +16,7 @@ func get(request events.APIGatewayProxyRequest) (any, int, error) {
 
 	switch {
 	case uid != "":
-		return "that feature has not been implemented", 400, nil
+		return nil, 400, fmt.Errorf("that feature has not been implemented")
 	default:
 		return getAllPost()
 	}
@@ -24,7 +25,7 @@ func get(request events.APIGatewayProxyRequest) (any, int, error) {
 func getAllPost() (any, int, error) {
 	sess, err := session.NewSession()
 	if err != nil {
-		return err.Error(), 500, nil
+		return nil, 500, err
 	}
 	db := dynamodb.New(sess)
 
@@ -46,13 +47,13 @@ func getAllPost() (any, int, error) {
 	}
 	result, err := db.Query(input)
 	if err != nil {
-		return err.Error(), 500, nil
+		return nil, 500, err
 	}
 
 	posts := []Post{}
 	err = dynamodbattribute.UnmarshalListOfMaps(result.Items, &posts)
 	if err != nil {
-		return err.Error(), 500, nil
+		return nil, 500, err
 	}
 	response := struct {
 		Posts []Post `json:"posts"`

--- a/Terraform/modules/lambda/src/posts/root-post.go
+++ b/Terraform/modules/lambda/src/posts/root-post.go
@@ -2,6 +2,7 @@ package posts
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -26,27 +27,27 @@ func post(request events.APIGatewayProxyRequest) (any, int, error) {
 	rb := RequestBody{}
 	err := json.Unmarshal([]byte(body), &rb)
 	if err != nil {
-		return "request body json unmarshal error", 400, nil
+		return nil, 400, fmt.Errorf("request body json unmarshal error")
 	}
 	if rb.UserId == nil || *rb.UserId == "" {
-		return "user id is required", 400, nil
+		return nil, 400, fmt.Errorf("user id is required")
 	}
 	if rb.Content == nil {
-		return "content is required", 400, nil
+		return nil, 400, fmt.Errorf("content is required")
 	}
 
 	switch {
 	case rb.Content.Comment != nil && *rb.Content.Comment != "":
 		return createPost(rb)
 	default:
-		return "content is required", 400, nil
+		return nil, 400, fmt.Errorf("content is required")
 	}
 }
 
 func createPost(requestBody RequestBody) (any, int, error) {
 	sess, err := session.NewSession()
 	if err != nil {
-		return err.Error(), 500, nil
+		return nil, 500, err
 	}
 	db := dynamodb.New(sess)
 
@@ -75,7 +76,7 @@ func createPost(requestBody RequestBody) (any, int, error) {
 
 	inputAV, err := dynamodbattribute.MarshalMap(post)
 	if err != nil {
-		return err.Error(), 500, nil
+		return nil, 500, err
 	}
 	tn := os.Getenv("POSTS_TABLE_NAME")
 	input := &dynamodb.PutItemInput{
@@ -84,7 +85,7 @@ func createPost(requestBody RequestBody) (any, int, error) {
 	}
 	_, err = db.PutItem(input)
 	if err != nil {
-		return err.Error(), 500, nil
+		return nil, 500, err
 	}
 
 	return post, 201, nil


### PR DESCRIPTION
close #21 
error発生時にerrを変換せずにroot-handlerまで返却
root-handlerではbodyにエラー内容を展開
lambdaとしての返却値にも発生したerrorを返却する