### PR TITLE
ユーザ名一覧取得APIの作成 #34

### DIFF
--- a/Terraform/modules/lambda/src/users/model.go
+++ b/Terraform/modules/lambda/src/users/model.go
@@ -5,3 +5,8 @@ type User struct {
 	DisplayName *string `dynamodbav:"displayName" json:"displayName"`
 	Identity    *string `dynamodbav:"identity" json:"identity"`
 }
+
+type PublicUser struct {
+	Id          *string `dynamodbav:"id" json:"id"`
+	DisplayName *string `dynamodbav:"displayName" json:"displayName"`
+}

--- a/Terraform/modules/lambda/src/users/root-get.go
+++ b/Terraform/modules/lambda/src/users/root-get.go
@@ -28,7 +28,7 @@ func getAllUser() (any, int, error) {
 			"#id":          aws.String("id"),
 			"#displayName": aws.String("displayName"),
 		},
-		ProjectionExpression: aws.String("id, #displayName"),
+		ProjectionExpression: aws.String("#id, #displayName"),
 	}
 	result, err := db.Scan(input)
 	if err != nil {

--- a/Terraform/modules/lambda/src/users/root-get.go
+++ b/Terraform/modules/lambda/src/users/root-get.go
@@ -1,0 +1,49 @@
+package users
+
+import (
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+func get(request events.APIGatewayProxyRequest) (any, int, error) {
+	return getAllUser()
+}
+
+func getAllUser() (any, int, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, 500, err
+	}
+	db := dynamodb.New(sess)
+
+	tn := os.Getenv("USERS_TABLE_NAME")
+	input := &dynamodb.ScanInput{
+		TableName: aws.String(tn),
+		ExpressionAttributeNames: map[string]*string{
+			"#id":          aws.String("id"),
+			"#displayName": aws.String("displayName"),
+		},
+		ProjectionExpression: aws.String("id, #displayName"),
+	}
+	result, err := db.Scan(input)
+	if err != nil {
+		return nil, 500, err
+	}
+
+	users := []PublicUser{}
+	err = dynamodbattribute.UnmarshalListOfMaps(result.Items, &users)
+	if err != nil {
+		return nil, 500, err
+	}
+	response := struct {
+		Users []PublicUser `json:"users"`
+	}{
+		Users: users,
+	}
+	return response, 200, nil
+}

--- a/Terraform/modules/lambda/src/users/root.go
+++ b/Terraform/modules/lambda/src/users/root.go
@@ -19,6 +19,8 @@ func Root(request events.APIGatewayProxyRequest) (any, int, error) {
 	if len(pathArray) == 0 {
 		method := request.HTTPMethod
 		switch method {
+		case "GET":
+			return get(request)
 		case "POST":
 			return post(request)
 		}


### PR DESCRIPTION
close #34 
/usersのGETに実装
ドキュメントに基づいた形式で返却する
identityが含まれないことは確認済み