### PR TITLE
ユーザ名変更APIの実装 #32

### DIFF
--- a/Terraform/modules/lambda/openapi.yaml
+++ b/Terraform/modules/lambda/openapi.yaml
@@ -511,7 +511,15 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/User'
+            type: object
+            properties:
+              displayName:
+                type: string
+              identity:
+                type: string
+            required:
+              - displayName
+              - identity
     deletePost:
       content:
         application/json:

--- a/Terraform/modules/lambda/openapi.yaml
+++ b/Terraform/modules/lambda/openapi.yaml
@@ -384,7 +384,7 @@ paths:
       responses:
         '201':
           $ref: '#/components/responses/putUser'
-      description: Userの更新
+      description: Userの更新(全体)
       parameters: []
       x-amazon-apigateway-integration:
         type: aws_proxy
@@ -511,17 +511,7 @@ components:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              id:
-                type: string
-              displayName:
-                type: string
-              identity:
-                type: string
-            required:
-              - id
-              - identity
+            $ref: '#/components/schemas/User'
     deletePost:
       content:
         application/json:

--- a/Terraform/modules/lambda/src/users/ddb.go
+++ b/Terraform/modules/lambda/src/users/ddb.go
@@ -1,0 +1,52 @@
+package users
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+func getUserFromId(id string) (*User, int, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, 500, err
+	}
+	db := dynamodb.New(sess)
+
+	tn := os.Getenv("USERS_TABLE_NAME")
+	in := os.Getenv("USERS_TABLE_GSI_NAME_IDENTITY")
+	input := &dynamodb.QueryInput{
+		TableName: aws.String(tn),
+		IndexName: aws.String(in),
+		ExpressionAttributeNames: map[string]*string{
+			"#id": aws.String("id"),
+		},
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":id": {
+				S: aws.String(id),
+			},
+		},
+		KeyConditionExpression: aws.String("#id = :id"),
+	}
+
+	output, err := db.Query(input)
+	if err != nil {
+		return nil, 500, err
+	}
+
+	if len(output.Items) == 0 {
+		return nil, 404, fmt.Errorf("user not found")
+	}
+
+	user := User{}
+	err = dynamodbattribute.UnmarshalMap(output.Items[0], &user)
+	if err != nil {
+		return nil, 500, err
+	}
+
+	return &user, 200, nil
+}

--- a/Terraform/modules/lambda/src/users/ddb.go
+++ b/Terraform/modules/lambda/src/users/ddb.go
@@ -18,10 +18,8 @@ func getUserFromId(id string) (*User, int, error) {
 	db := dynamodb.New(sess)
 
 	tn := os.Getenv("USERS_TABLE_NAME")
-	in := os.Getenv("USERS_TABLE_GSI_NAME_IDENTITY")
 	input := &dynamodb.QueryInput{
 		TableName: aws.String(tn),
-		IndexName: aws.String(in),
 		ExpressionAttributeNames: map[string]*string{
 			"#id": aws.String("id"),
 		},

--- a/Terraform/modules/lambda/src/users/pid-put.go
+++ b/Terraform/modules/lambda/src/users/pid-put.go
@@ -1,0 +1,71 @@
+package users
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+type UpdateUserRequest = User
+
+func pidPut(request events.APIGatewayProxyRequest) (any, int, error) {
+	body := request.Body
+	ur := UpdateUserRequest{}
+	err := json.Unmarshal([]byte(body), &ur)
+	if err != nil {
+		return nil, 400, fmt.Errorf("request body json unmarshal error")
+	}
+	if ur.Id == nil || ur.DisplayName == nil || ur.Identity == nil || *ur.DisplayName == "" || *ur.Id == "" || *ur.Identity == "" {
+		return nil, 400, fmt.Errorf("id, displayName and identity are required")
+	}
+
+	return updateUser(ur)
+}
+
+func updateUser(ur UpdateUserRequest) (any, int, error) {
+	fu, st, err := getUserFromId(*ur.Id)
+	if err != nil {
+		return nil, st, err
+	}
+	if *fu.Identity != *ur.Identity {
+		return nil, 400, fmt.Errorf("identity cannot be changed")
+	}
+
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, 500, err
+	}
+	db := dynamodb.New(sess)
+
+	user := User{
+		Id:          ur.Id,
+		DisplayName: ur.DisplayName,
+		Identity:    ur.Identity,
+	}
+
+	av, err := dynamodbattribute.MarshalMap(user)
+	if err != nil {
+		return nil, 500, err
+	}
+	tn := os.Getenv("USERS_TABLE_NAME")
+	input := &dynamodb.PutItemInput{
+		Item:      av,
+		TableName: aws.String(tn),
+	}
+	_, err = db.PutItem(input)
+	if err != nil {
+		return nil, 500, err
+	}
+	rs := struct {
+		User User `json:"user"`
+	}{
+		User: user,
+	}
+	return rs, 200, nil
+}

--- a/Terraform/modules/lambda/src/users/pid-put.go
+++ b/Terraform/modules/lambda/src/users/pid-put.go
@@ -55,8 +55,8 @@ func updateUser(ur UpdateUserRequest) (any, int, error) {
 	}
 	tn := os.Getenv("USERS_TABLE_NAME")
 	input := &dynamodb.PutItemInput{
-		Item:      av,
 		TableName: aws.String(tn),
+		Item:      av,
 	}
 	_, err = db.PutItem(input)
 	if err != nil {

--- a/Terraform/modules/lambda/src/users/root.go
+++ b/Terraform/modules/lambda/src/users/root.go
@@ -26,5 +26,18 @@ func Root(request events.APIGatewayProxyRequest) (any, int, error) {
 		}
 		return nil, 400, fmt.Errorf("method %s is not allowed", method)
 	}
+
+	id := request.PathParameters["id"]
+	if id != "" {
+		pathArray = pathArray[1:]
+		if len(pathArray) == 0 {
+			method := request.HTTPMethod
+			switch method {
+			case "PUT":
+				return pidPut(request)
+			}
+			return nil, 400, fmt.Errorf("method %s is not allowed", method)
+		}
+	}
 	return nil, 400, fmt.Errorf("resource is not allowed")
 }


### PR DESCRIPTION
close #32 
ユーザの情報を更新するAPIを実装した
なお、置き換える形での更新になり、ユーザ名に限らず変更となる（idとidentity除く）ため、後に属性を増やす場合は修正が必須