### PR TITLE
ハンドラー層でのエラー対応を変更 #39

### DIFF
--- a/Terraform/modules/lambda/src/handler.go
+++ b/Terraform/modules/lambda/src/handler.go
@@ -32,20 +32,20 @@ func jsonResponse(body any, statusCode int, err error) (events.APIGatewayProxyRe
 				Body:       "respons body json marshal error",
 				StatusCode: 500,
 				Headers:    header,
-			}, err3
+			}, nil
 		}
 		return events.APIGatewayProxyResponse{
 			Body:       string(jsonBytes),
 			StatusCode: 500,
 			Headers:    header,
-		}, err2
+		}, nil
 	}
 
 	return events.APIGatewayProxyResponse{
 		Body:       string(jsonBytes),
 		StatusCode: statusCode,
 		Headers:    header,
-	}, err
+	}, nil
 }
 
 func HandleRequest(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {

--- a/Terraform/modules/lambda/src/users/ddb.go
+++ b/Terraform/modules/lambda/src/users/ddb.go
@@ -56,7 +56,7 @@ func UserVerification(id string, identity string) (any, int, error) {
 	}
 
 	if user.Identity == nil || *user.Identity != identity {
-		return nil, 401, fmt.Errorf("fail to verify user")
+		return nil, 401, fmt.Errorf("user verification failed")
 	}
 
 	return "OK", 200, nil


### PR DESCRIPTION
close #39 
変更し、APIGatewayからエラーがbody部で確認できることを確認した。
ついでに若干の表現の変更を加えた