### PR TITLE
APIGateway + S3 で画像を扱う調査・仮作成 #52

### DIFF
--- a/Terraform/main.tf
+++ b/Terraform/main.tf
@@ -36,7 +36,8 @@ locals {
 
 module "lambda" {
   depends_on = [
-    module.dynamoDB
+    module.dynamoDB,
+    module.s3,
   ]
   source                        = "./modules/lambda"
   identifier                    = local.identifier
@@ -48,6 +49,7 @@ module "lambda" {
   posts_table_gsi_name_usr      = local.gsi_name_usr
   users_table_name              = module.dynamoDB.users_table_name
   users_table_gsi_name_identity = local.gsi_name_identity
+  image_bucket_name             = module.s3.bucket_name
 }
 
 module "dynamoDB" {
@@ -56,4 +58,10 @@ module "dynamoDB" {
   gsi_name_all      = local.gsi_name_all
   gsi_name_usr      = local.gsi_name_usr
   gsi_name_identity = local.gsi_name_identity
+}
+
+module "s3" {
+  source     = "./modules/s3"
+  identifier = "${local.identifier}-image"
+  env        = var.env
 }

--- a/Terraform/modules/lambda/apigateway.tf
+++ b/Terraform/modules/lambda/apigateway.tf
@@ -16,13 +16,14 @@ data "template_file" "openapi" {
     auth_provider_arn   = aws_cognito_user_pool.this.arn
     integration_uri     = aws_lambda_function.this.invoke_arn
     credential_role_arn = aws_iam_role.api2lambda.arn
+    image_bucket_name   = var.image_bucket_name
   }
 }
 
 # IAM Role for API Gateway Execution Lambda
 resource "aws_iam_role" "api2lambda" {
   name                = "${var.identifier}-apigateway-lambda-role"
-  managed_policy_arns = [aws_iam_policy.api2lambda.arn]
+  managed_policy_arns = [aws_iam_policy.api2lambda.arn, aws_iam_policy.api2s3.arn]
 
   assume_role_policy = <<EOF
 {
@@ -58,6 +59,26 @@ resource "aws_iam_policy" "api2lambda" {
   ]
 }
 EOF
+}
+
+resource "aws_iam_policy" "api2s3" {
+  name = "${var.identifier}-apigateway-s3-policy"
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "s3:PutObject",
+          "s3:GetObject"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }
+  EOF
 }
 
 # deploy

--- a/Terraform/modules/lambda/openapi.yaml
+++ b/Terraform/modules/lambda/openapi.yaml
@@ -397,106 +397,119 @@ paths:
         $ref: '#/components/requestBodies/putUser'
       tags:
         - User
-  /timages/{item}:
+  '/images/{item}':
     get:
       produces:
-      - "application/json"
+        - application/json
       parameters:
-      - name: "item"
-        in: "path"
-        required: true
-        type: "string"
+        - name: item
+          in: path
+          required: true
+          type: string
       responses:
-        "200":
-          description: "200 response"
+        '200':
+          description: 200 response
           schema:
-            $ref: "#/definitions/Empty"
+            $ref: '#/definitions/Empty'
           headers:
             Access-Control-Allow-Origin:
-              type: "string"
+              type: string
             Content-Disposition:
-              type: "string"
+              type: string
             Content-Type:
-              type: "string"
+              type: string
       x-amazon-apigateway-integration:
-        type: "aws"
-        uri: "arn:aws:apigateway:ap-northeast-1:s3:path/${image_bucket_name}/{object}"
+        type: aws
+        uri: 'arn:aws:apigateway:ap-northeast-1:s3:path/${image_bucket_name}/{object}'
         credentials: '${credential_role_arn}'
-        httpMethod: "GET"
+        httpMethod: GET
         responses:
           default:
-            statusCode: "200"
+            statusCode: '200'
             responseParameters:
-              method.response.header.Content-Disposition: "'attachment; filename=\"download\"'"
-              method.response.header.Content-Type: "integration.response.header.Content-Type"
-              method.response.header.Access-Control-Allow-Origin: "'*'"
+              method.response.header.Content-Disposition: '''attachment; filename="download"'''
+              method.response.header.Content-Type: integration.response.header.Content-Type
+              method.response.header.Access-Control-Allow-Origin: '''*'''
         requestParameters:
-          integration.request.path.object: "method.request.path.item"
-        passthroughBehavior: "when_no_match"
+          integration.request.path.object: method.request.path.item
+        passthroughBehavior: when_no_match
+      operationId: ''
+      tags:
+        - Image
     put:
       produces:
-      - "application/json"
+        - application/json
       parameters:
-      - name: "item"
-        in: "path"
-        required: true
-        type: "string"
+        - name: item
+          in: path
+          required: true
+          type: string
       responses:
-        "200":
-          description: "200 response"
+        '200':
+          description: 200 response
           schema:
-            $ref: "#/definitions/Empty"
+            $ref: '#/definitions/Empty'
           headers:
             Access-Control-Allow-Origin:
-              type: "string"
+              type: string
       x-amazon-apigateway-integration:
-        type: "aws"
-        uri: "arn:aws:apigateway:ap-northeast-1:s3:path/${image_bucket_name}/{object}"
+        type: aws
+        uri: 'arn:aws:apigateway:ap-northeast-1:s3:path/${image_bucket_name}/{object}'
         credentials: '${credential_role_arn}'
-        httpMethod: "PUT"
+        httpMethod: PUT
         responses:
           default:
-            statusCode: "200"
+            statusCode: '200'
             responseParameters:
-              method.response.header.Access-Control-Allow-Origin: "'*'"
+              method.response.header.Access-Control-Allow-Origin: '''*'''
         requestParameters:
-          integration.request.path.object: "method.request.path.item"
-        passthroughBehavior: "when_no_match"
+          integration.request.path.object: method.request.path.item
+        passthroughBehavior: when_no_match
+      tags:
+        - Image
     options:
       security: []
       consumes:
-      - "application/json"
+        - application/json
       produces:
-      - "application/json"
+        - application/json
       parameters:
-      - name: "item"
-        in: "path"
-        required: true
-        type: "string"
+        - name: item
+          in: path
+          required: true
+          type: string
       responses:
-        "200":
-          description: "200 response"
+        '200':
+          description: 200 response
           schema:
-            $ref: "#/definitions/Empty"
+            $ref: '#/definitions/Empty'
           headers:
             Access-Control-Allow-Origin:
-              type: "string"
+              type: string
             Access-Control-Allow-Methods:
-              type: "string"
+              type: string
             Access-Control-Allow-Headers:
-              type: "string"
+              type: string
       x-amazon-apigateway-integration:
-        type: "mock"
+        type: mock
         responses:
           default:
-            statusCode: "200"
+            statusCode: '200'
             responseParameters:
-              method.response.header.Access-Control-Allow-Methods: "'GET,OPTIONS,PUT'"
-              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
-              method.response.header.Access-Control-Allow-Origin: "'*'"
+              method.response.header.Access-Control-Allow-Methods: '''GET,OPTIONS,PUT'''
+              method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'''
+              method.response.header.Access-Control-Allow-Origin: '''*'''
         requestTemplates:
-          application/json: "{\"statusCode\": 200}"
-        passthroughBehavior: "when_no_match"
+          application/json: '{"statusCode": 200}'
+        passthroughBehavior: when_no_match
+      tags:
+        - Test
+    parameters:
+      - schema:
+          type: string
+        name: item
+        in: path
+        required: true
 components:
   schemas:
     Post:
@@ -686,10 +699,11 @@ components:
               - user
 x-internal: true
 tags:
+  - name: Image
   - name: Post
   - name: Test
   - name: User
 security:
   - '${auth}': []
 x-amazon-apigateway-binary-media-types:
-- "image/*"
+  - image/*

--- a/Terraform/modules/lambda/openapi.yaml
+++ b/Terraform/modules/lambda/openapi.yaml
@@ -397,6 +397,106 @@ paths:
         $ref: '#/components/requestBodies/putUser'
       tags:
         - User
+  /timages/{item}:
+    get:
+      produces:
+      - "application/json"
+      parameters:
+      - name: "item"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "200 response"
+          schema:
+            $ref: "#/definitions/Empty"
+          headers:
+            Access-Control-Allow-Origin:
+              type: "string"
+            Content-Disposition:
+              type: "string"
+            Content-Type:
+              type: "string"
+      x-amazon-apigateway-integration:
+        type: "aws"
+        uri: "arn:aws:apigateway:ap-northeast-1:s3:path/${image_bucket_name}/{object}"
+        credentials: '${credential_role_arn}'
+        httpMethod: "GET"
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Content-Disposition: "'attachment; filename=\"download\"'"
+              method.response.header.Content-Type: "integration.response.header.Content-Type"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestParameters:
+          integration.request.path.object: "method.request.path.item"
+        passthroughBehavior: "when_no_match"
+    put:
+      produces:
+      - "application/json"
+      parameters:
+      - name: "item"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "200 response"
+          schema:
+            $ref: "#/definitions/Empty"
+          headers:
+            Access-Control-Allow-Origin:
+              type: "string"
+      x-amazon-apigateway-integration:
+        type: "aws"
+        uri: "arn:aws:apigateway:ap-northeast-1:s3:path/${image_bucket_name}/{object}"
+        credentials: '${credential_role_arn}'
+        httpMethod: "PUT"
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestParameters:
+          integration.request.path.object: "method.request.path.item"
+        passthroughBehavior: "when_no_match"
+    options:
+      security: []
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "item"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "200 response"
+          schema:
+            $ref: "#/definitions/Empty"
+          headers:
+            Access-Control-Allow-Origin:
+              type: "string"
+            Access-Control-Allow-Methods:
+              type: "string"
+            Access-Control-Allow-Headers:
+              type: "string"
+      x-amazon-apigateway-integration:
+        type: "mock"
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Methods: "'GET,OPTIONS,PUT'"
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
+              method.response.header.Access-Control-Allow-Origin: "'*'"
+        requestTemplates:
+          application/json: "{\"statusCode\": 200}"
+        passthroughBehavior: "when_no_match"
 components:
   schemas:
     Post:
@@ -591,3 +691,5 @@ tags:
   - name: User
 security:
   - '${auth}': []
+x-amazon-apigateway-binary-media-types:
+- "image/*"

--- a/Terraform/modules/lambda/variables.tf
+++ b/Terraform/modules/lambda/variables.tf
@@ -26,3 +26,6 @@ variable "users_table_name" {
 variable "users_table_gsi_name_identity" {
   type = string
 }
+variable "image_bucket_name" {
+  type = string
+}

--- a/Terraform/modules/s3/output.tf
+++ b/Terraform/modules/s3/output.tf
@@ -1,0 +1,3 @@
+output "bucket_name" {
+  value = aws_s3_bucket.this.bucket
+}

--- a/Terraform/modules/s3/s3.tf
+++ b/Terraform/modules/s3/s3.tf
@@ -1,0 +1,25 @@
+resource "aws_s3_bucket" "this" {
+  bucket        = "${var.identifier}-s3"
+  force_destroy = var.env == "tst" ? true : false
+}
+resource "aws_s3_bucket_acl" "this" {
+  bucket = aws_s3_bucket.this.bucket
+  acl    = "private"
+}
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/Terraform/modules/s3/variables.tf
+++ b/Terraform/modules/s3/variables.tf
@@ -1,0 +1,6 @@
+variable "identifier" {
+  type = string
+}
+variable "env" {
+  type = string
+}


### PR DESCRIPTION
close #52 
画像のPUT/GETを行うAPIの仮作成を行った
APIGatewayを介してS3へアクセスを行う
後はフロントエンド部分で制御すれば、画像の表示が可能