### PR TITLE
画像関係の設計 #54

### DIFF
--- a/Terraform/modules/lambda/openapi.yaml
+++ b/Terraform/modules/lambda/openapi.yaml
@@ -535,6 +535,8 @@ components:
           properties:
             comment:
               type: string
+            image:
+              $ref: '#/components/schemas/Image'
         reactions:
           type: array
           items:
@@ -577,6 +579,19 @@ components:
       required:
         - id
         - displayName
+    Image:
+      title: Image
+      x-stoplight:
+        id: nwn13xbxiu16j
+      type: object
+      properties:
+        originId:
+          type: string
+        compressedId:
+          type: string
+      required:
+        - originId
+        - compressedId
   securitySchemes:
     '${auth}':
       type: apiKey
@@ -603,6 +618,8 @@ components:
                 properties:
                   comment:
                     type: string
+                  image:
+                    $ref: '#/components/schemas/Image'
             required:
               - userId
               - content


### PR DESCRIPTION
close #54 
Image型を追加。要素はbucketのkeyとなる二つのid(オリジナルと圧縮後)
この要素をpost.contentが持つ場合がある